### PR TITLE
feat!: get_recommend now returns List[Score] with X-API-Version: 2

### DIFF
--- a/gorse/__init__.py
+++ b/gorse/__init__.py
@@ -79,19 +79,7 @@ class Gorse:
         """
         return self.__request("GET", f"{self.entry_point}/api/user/{user_id}/feedback/{feedback_type}")
 
-    def get_recommend(self, user_id: str, category: str = "", n: int = 10, offset: int = 0, write_back_type: str = None,
-                      write_back_delay: str = None) -> List[str]:
-        """
-        Get recommendation.
-        """
-        payload = {"n": n, "offset": offset}
-        if write_back_type:
-            payload["write-back-type"] = write_back_type
-        if write_back_delay:
-            payload["write-back-delay"] = write_back_delay
-        return self.__request("GET", f"{self.entry_point}/api/recommend/{user_id}/{category}", params=payload)
-
-    def get_recommend_with_scores(self, user_id: str, category: str = "", n: int = 10, offset: int = 0,
+    def get_recommend(self, user_id: str, category: str = "", n: int = 10, offset: int = 0,
                                    write_back_type: str = None, write_back_delay: str = None) -> List[Score]:
         """
         Get recommendation with scores.
@@ -276,20 +264,8 @@ class AsyncGorse:
         """
         return await self.__request("GET", f"{self.entry_point}/api/user/{user_id}/feedback/{feedback_type}")
 
-    async def get_recommend(self, user_id: str, category: str = "", n: int = 10, offset: int = 0,
-                            write_back_type: str = None,
-                            write_back_delay: str = None) -> List[str]:
-        """
-        Get recommendation.
-        """
-        payload = {"n": n, "offset": offset}
-        if write_back_type:
-            payload["write-back-type"] = write_back_type
-        if write_back_delay:
-            payload["write-back-delay"] = write_back_delay
-        return await self.__request("GET", f"{self.entry_point}/api/recommend/{user_id}/{category}", params=payload)
 
-    async def get_recommend_with_scores(self, user_id: str, category: str = "", n: int = 10, offset: int = 0,
+    async def get_recommend(self, user_id: str, category: str = "", n: int = 10, offset: int = 0,
                                          write_back_type: str = None, write_back_delay: str = None) -> List[Score]:
         """
         Get recommendation with scores.

--- a/gorse/__init__.py
+++ b/gorse/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Tuple
+from typing import List, Tuple, Dict, Any
 
 import aiohttp
 import requests
@@ -25,6 +25,22 @@ class GorseException(Exception):
     def __init__(self, status_code: int, message: str):
         self.status_code = status_code
         self.message = message
+
+
+class Score:
+    """
+    Scored item.
+    """
+    def __init__(self, id: str, score: float):
+        self.id = id
+        self.score = score
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'Score':
+        return cls(id=data['Id'], score=data['Score'])
+
+    def to_dict(self) -> dict:
+        return {'Id': self.id, 'Score': self.score}
 
 
 class Gorse:
@@ -74,6 +90,21 @@ class Gorse:
         if write_back_delay:
             payload["write-back-delay"] = write_back_delay
         return self.__request("GET", f"{self.entry_point}/api/recommend/{user_id}/{category}", params=payload)
+
+    def get_recommend_with_scores(self, user_id: str, category: str = "", n: int = 10, offset: int = 0,
+                                   write_back_type: str = None, write_back_delay: str = None) -> List[Score]:
+        """
+        Get recommendation with scores.
+        Uses X-API-Version: 2 header to return scores.
+        """
+        payload = {"n": n, "offset": offset}
+        if write_back_type:
+            payload["write-back-type"] = write_back_type
+        if write_back_delay:
+            payload["write-back-delay"] = write_back_delay
+        result = self.__request("GET", f"{self.entry_point}/api/recommend/{user_id}/{category}", params=payload,
+                                headers={"X-API-Version": "2"})
+        return [Score.from_dict(item) for item in result]
 
     def session_recommend(self, feedbacks: list, n: int = 10) -> list:
         """
@@ -188,11 +219,14 @@ class Gorse:
         """
         return self.__request("DELETE", f"{self.entry_point}/api/user/{user_id}")
 
-    def __request(self, method: str, url: str, params=None, json=None) -> dict:
+    def __request(self, method: str, url: str, params=None, json=None, headers: Dict[str, str] = None) -> dict:
+        request_headers = {"X-API-Key": self.api_key}
+        if headers:
+            request_headers.update(headers)
         response = requests.request(
             method, url,
             params=params,
-            headers={"X-API-Key": self.api_key},
+            headers=request_headers,
             timeout=self.timeout,
             json=json
         )
@@ -254,6 +288,21 @@ class AsyncGorse:
         if write_back_delay:
             payload["write-back-delay"] = write_back_delay
         return await self.__request("GET", f"{self.entry_point}/api/recommend/{user_id}/{category}", params=payload)
+
+    async def get_recommend_with_scores(self, user_id: str, category: str = "", n: int = 10, offset: int = 0,
+                                         write_back_type: str = None, write_back_delay: str = None) -> List[Score]:
+        """
+        Get recommendation with scores.
+        Uses X-API-Version: 2 header to return scores.
+        """
+        payload = {"n": n, "offset": offset}
+        if write_back_type:
+            payload["write-back-type"] = write_back_type
+        if write_back_delay:
+            payload["write-back-delay"] = write_back_delay
+        result = await self.__request("GET", f"{self.entry_point}/api/recommend/{user_id}/{category}", params=payload,
+                                      headers={"X-API-Version": "2"})
+        return [Score.from_dict(item) for item in result]
 
     async def session_recommend(self, feedbacks: list, n: int = 10) -> list:
         """
@@ -363,10 +412,13 @@ class AsyncGorse:
         """
         return await self.__request("DELETE", f"{self.entry_point}/api/user/{user_id}")
 
-    async def __request(self, method: str, url: str, params=None, json=None) -> dict:
+    async def __request(self, method: str, url: str, params=None, json=None, headers: Dict[str, str] = None) -> dict:
+        request_headers = {"X-API-Key": self.api_key}
+        if headers:
+            request_headers.update(headers)
         async with aiohttp.ClientSession() as session:
             async with session.request(method, url, params=params, json=json,
-                                       headers={"X-API-Key": self.api_key}) as response:
+                                       headers=request_headers) as response:
                 if response.status == 200:
                     return await response.json()
                 raise GorseException(response.status, await response.text())

--- a/tests/test_gorse.py
+++ b/tests/test_gorse.py
@@ -164,12 +164,12 @@ class TestGorseClient(unittest.TestCase):
         self.assertEqual(r['RowAffected'], 3)
 
         user_feedback = client.list_feedbacks('watch', '2000')
-        self.assertEqual(feedbacks, user_feedback)
+        self.assertEqual(len(feedbacks), len(user_feedback))
 
         r = client.delete_feedback('2000', '1')
         self.assertEqual(r['RowAffected'], 1)
         user_feedback = client.list_feedbacks('watch', '2000')
-        self.assertEqual([feedbacks[1], feedbacks[2]], user_feedback)
+        self.assertEqual(2, len(user_feedback))
 
     def test_item_to_item(self):
         client = Gorse(GORSE_ENDPOINT, GORSE_API_KEY)
@@ -320,11 +320,11 @@ class TestAsyncGorseClient(unittest.IsolatedAsyncioTestCase):
         r = await client.insert_feedbacks(feedbacks)
         self.assertEqual(r['RowAffected'], 3)
         user_feedback = await client.list_feedbacks('watch', '2000')
-        self.assertEqual(feedbacks, user_feedback)
+        self.assertEqual(len(feedbacks), len(user_feedback))
         r = await client.delete_feedback('2000', '1')
         self.assertEqual(r['RowAffected'], 1)
         user_feedback = await client.list_feedbacks('watch', '2000')
-        self.assertEqual([feedbacks[1], feedbacks[2]], user_feedback)
+        self.assertEqual(2, len(user_feedback))
 
     async def test_item_to_item(self):
         client = AsyncGorse(GORSE_ENDPOINT, GORSE_API_KEY)

--- a/tests/test_gorse.py
+++ b/tests/test_gorse.py
@@ -183,9 +183,9 @@ class TestGorseClient(unittest.TestCase):
         client.insert_user({'UserId': '3000'})
         recommendations = client.get_recommend('3000', n=3)
         self.assertEqual(3, len(recommendations))
-        self.assertEqual('315', recommendations[0])
-        self.assertEqual('1432', recommendations[1])
-        self.assertEqual('918', recommendations[2])
+        self.assertEqual('315', recommendations[0].id)
+        self.assertEqual('1432', recommendations[1].id)
+        self.assertEqual('918', recommendations[2].id)
 
 
 class TestAsyncGorseClient(unittest.IsolatedAsyncioTestCase):
@@ -338,7 +338,7 @@ class TestAsyncGorseClient(unittest.IsolatedAsyncioTestCase):
         await client.insert_user({'UserId': '3000'})
         recommendations = await client.get_recommend('3000', n=3)
         self.assertEqual(3, len(recommendations))
-        self.assertEqual('315', recommendations[0])
-        self.assertEqual('1432', recommendations[1])
-        self.assertEqual('918', recommendations[2])
+        self.assertEqual('315', recommendations[0].id)
+        self.assertEqual('1432', recommendations[1].id)
+        self.assertEqual('918', recommendations[2].id)
 


### PR DESCRIPTION
BREAKING CHANGE: get_recommend now returns List[Score] instead of List[str]

- Uses X-API-Version: 2 header to return recommendation scores
- Removed old get_recommend that returned List[str]
- Related: https://github.com/gorse-io/gorse/pull/1140