### PR TITLE
test: cover feedback labels

### DIFF
--- a/tests/test_gorse.py
+++ b/tests/test_gorse.py
@@ -147,6 +147,7 @@ class TestGorseClient(unittest.TestCase):
                 'ItemId': '1060',
                 'Value': 2.0,
                 'Timestamp': datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                'Labels': ['movie', 'positive'],
                 'Comment': ''
             },
             {
@@ -155,6 +156,7 @@ class TestGorseClient(unittest.TestCase):
                 'ItemId': '11',
                 'Value': 3.0,
                 'Timestamp': datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                'Labels': ['source:test', 'device:web'],
                 'Comment': ''
             }
         ]
@@ -304,6 +306,7 @@ class TestAsyncGorseClient(unittest.IsolatedAsyncioTestCase):
                 'ItemId': '1060',
                 'Value': 2.0,
                 'Timestamp': datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                'Labels': ['movie', 'positive'],
                 'Comment': ''
             },
             {
@@ -312,6 +315,7 @@ class TestAsyncGorseClient(unittest.IsolatedAsyncioTestCase):
                 'ItemId': '11',
                 'Value': 3.0,
                 'Timestamp': datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                'Labels': ['source:test', 'device:web'],
                 'Comment': ''
             }
         ]
@@ -341,4 +345,3 @@ class TestAsyncGorseClient(unittest.IsolatedAsyncioTestCase):
         self.assertEqual('315', recommendations[0].id)
         self.assertEqual('1432', recommendations[1].id)
         self.assertEqual('918', recommendations[2].id)
-


### PR DESCRIPTION
## Summary\n- add labels to part of the feedbacks inserted in sync and async feedback tests\n- keep the existing list_feedbacks assertions to verify labeled feedback inserts successfully participate in feedback queries\n\n## Tests\n- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile tests/test_gorse.py\n- git diff --check\n\nNote: the failed CI run showed list_feedbacks in the test service response does not include Labels, so this PR verifies insertion of labeled feedback without asserting returned Labels.