### PR TITLE
Add SearchItems API

### DIFF
--- a/gorse/__init__.py
+++ b/gorse/__init__.py
@@ -152,6 +152,17 @@ class Gorse:
             "GET", f"{self.entry_point}/api/items", params={'n': n, 'cursor': cursor})
         return response['Items'], response['Cursor']
 
+    def search_items(self, query: str, n: int = 10) -> List[dict]:
+        """
+        Search items.
+        :param query: search query
+        :param n: number of returned items
+        :return: items
+        """
+        response = self.__request(
+            "GET", f"{self.entry_point}/api/items", params={'q': query, 'n': n})
+        return response['Items']
+
     def update_item(self, item_id: str, is_hidden: bool = None, categories: List[str] = None, labels: List[str] = None,
                     timestamp: str = None,
                     comment: str = None) -> dict:
@@ -331,6 +342,17 @@ class AsyncGorse:
         response = await self.__request(
             "GET", f"{self.entry_point}/api/items", params={'n': n, 'cursor': cursor})
         return response['Items'], response['Cursor']
+
+    async def search_items(self, query: str, n: int = 10) -> List[dict]:
+        """
+        Search items.
+        :param query: search query
+        :param n: number of returned items
+        :return: items
+        """
+        response = await self.__request(
+            "GET", f"{self.entry_point}/api/items", params={'q': query, 'n': n})
+        return response['Items']
 
     async def update_item(self, item_id: str, is_hidden: bool = None, categories: List[str] = None,
                           labels: List[str] = None,

--- a/tests/test_gorse.py
+++ b/tests/test_gorse.py
@@ -128,6 +128,13 @@ class TestGorseClient(unittest.TestCase):
         except GorseException as e:
             self.assertEqual(e.status_code, 404)
 
+    def test_search_items(self):
+        client = Gorse(GORSE_ENDPOINT, GORSE_API_KEY)
+        items = client.search_items('Toy Story', 3)
+        self.assertGreater(len(items), 0)
+        self.assertEqual('1', items[0]['ItemId'])
+        self.assertEqual('Toy Story (1995)', items[0]['Comment'])
+
     def test_feedback(self):
         client = Gorse(GORSE_ENDPOINT, GORSE_API_KEY)
         client.insert_user({'UserId': '2000'})
@@ -286,6 +293,13 @@ class TestAsyncGorseClient(unittest.IsolatedAsyncioTestCase):
         except GorseException as e:
             self.assertEqual(e.status_code, 404)
 
+    async def test_search_items(self):
+        client = AsyncGorse(GORSE_ENDPOINT, GORSE_API_KEY)
+        items = await client.search_items('Toy Story', 3)
+        self.assertGreater(len(items), 0)
+        self.assertEqual('1', items[0]['ItemId'])
+        self.assertEqual('Toy Story (1995)', items[0]['Comment'])
+
     async def test_feedback(self):
         client = AsyncGorse(GORSE_ENDPOINT, GORSE_API_KEY)
         await client.insert_user({'UserId': '2000'})
@@ -341,4 +355,3 @@ class TestAsyncGorseClient(unittest.IsolatedAsyncioTestCase):
         self.assertEqual('315', recommendations[0].id)
         self.assertEqual('1432', recommendations[1].id)
         self.assertEqual('918', recommendations[2].id)
-


### PR DESCRIPTION
Adds SearchItems support to the PyGorse client, following gorse-go commit 062d740c10a2aaef57c533fc007c3fb9244b83d3.

Changes:
- Add `Gorse.search_items(query, n=10)` for `GET /api/items?q=...&n=...`
- Add `AsyncGorse.search_items(query, n=10)`
- Add sync and async integration tests for searching `Toy Story`

Verification:
- `python3 -m py_compile gorse/__init__.py tests/test_gorse.py`

Not run:
- `python3 -m pytest tests/test_gorse.py -q` because pytest is not installed in this environment
- `python3 -m unittest tests.test_gorse -v` because aiohttp is not installed in this environment