### PR TITLE
feat: support multiple recommendation categories

### DIFF
--- a/gorse/__init__.py
+++ b/gorse/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Tuple, Dict, Any
+from typing import List, Tuple, Dict, Any, Union
 
 import aiohttp
 import requests
@@ -79,18 +79,20 @@ class Gorse:
         """
         return self.__request("GET", f"{self.entry_point}/api/user/{user_id}/feedback/{feedback_type}")
 
-    def get_recommend(self, user_id: str, category: str = "", n: int = 10, offset: int = 0,
+    def get_recommend(self, user_id: str, category: Union[str, List[str]] = "", n: int = 10, offset: int = 0,
                                    write_back_type: str = None, write_back_delay: str = None) -> List[Score]:
         """
         Get recommendation with scores.
         Uses X-API-Version: 2 header to return scores.
         """
-        payload = {"n": n, "offset": offset}
+        payload: Dict[str, Any] = {"n": n, "offset": offset}
+        if category:
+            payload["category"] = category
         if write_back_type:
             payload["write-back-type"] = write_back_type
         if write_back_delay:
             payload["write-back-delay"] = write_back_delay
-        result = self.__request("GET", f"{self.entry_point}/api/recommend/{user_id}/{category}", params=payload,
+        result = self.__request("GET", f"{self.entry_point}/api/recommend/{user_id}", params=payload,
                                 headers={"X-API-Version": "2"})
         return [Score.from_dict(item) for item in result]
 
@@ -276,18 +278,20 @@ class AsyncGorse:
         return await self.__request("GET", f"{self.entry_point}/api/user/{user_id}/feedback/{feedback_type}")
 
 
-    async def get_recommend(self, user_id: str, category: str = "", n: int = 10, offset: int = 0,
+    async def get_recommend(self, user_id: str, category: Union[str, List[str]] = "", n: int = 10, offset: int = 0,
                                          write_back_type: str = None, write_back_delay: str = None) -> List[Score]:
         """
         Get recommendation with scores.
         Uses X-API-Version: 2 header to return scores.
         """
-        payload = {"n": n, "offset": offset}
+        payload: Dict[str, Any] = {"n": n, "offset": offset}
+        if category:
+            payload["category"] = category
         if write_back_type:
             payload["write-back-type"] = write_back_type
         if write_back_delay:
             payload["write-back-delay"] = write_back_delay
-        result = await self.__request("GET", f"{self.entry_point}/api/recommend/{user_id}/{category}", params=payload,
+        result = await self.__request("GET", f"{self.entry_point}/api/recommend/{user_id}", params=payload,
                                       headers={"X-API-Version": "2"})
         return [Score.from_dict(item) for item in result]
 

--- a/tests/test_gorse.py
+++ b/tests/test_gorse.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from datetime import datetime, UTC
 import unittest
-from unittest.mock import AsyncMock, Mock
 
 from gorse import Gorse, GorseException, AsyncGorse
 
@@ -197,15 +196,13 @@ class TestGorseClient(unittest.TestCase):
 
     def test_recommend_multiple_categories(self):
         client = Gorse(GORSE_ENDPOINT, GORSE_API_KEY)
-        request = Mock(return_value=[])
-        setattr(client, '_Gorse__request', request)
-
-        client.get_recommend('3000', category=['Drama', 'Comedy'], n=3)
-
-        request.assert_called_once_with(
-            'GET', f'{GORSE_ENDPOINT}/api/recommend/3000',
-            params={'n': 3, 'offset': 0, 'category': ['Drama', 'Comedy']},
-            headers={'X-API-Version': '2'})
+        client.insert_user({'UserId': '3000'})
+        recommendations = client.get_recommend(
+            '3000', category=['Drama', 'Comedy'], n=3)
+        self.assertEqual(3, len(recommendations))
+        for recommendation in recommendations:
+            item = client.get_item(recommendation.id)
+            self.assertTrue({'Drama', 'Comedy'} & set(item['Categories']))
 
 
 class TestAsyncGorseClient(unittest.IsolatedAsyncioTestCase):
@@ -371,12 +368,10 @@ class TestAsyncGorseClient(unittest.IsolatedAsyncioTestCase):
 
     async def test_recommend_multiple_categories(self):
         client = AsyncGorse(GORSE_ENDPOINT, GORSE_API_KEY)
-        request = AsyncMock(return_value=[])
-        setattr(client, '_AsyncGorse__request', request)
-
-        await client.get_recommend('3000', category=['Drama', 'Comedy'], n=3)
-
-        request.assert_awaited_once_with(
-            'GET', f'{GORSE_ENDPOINT}/api/recommend/3000',
-            params={'n': 3, 'offset': 0, 'category': ['Drama', 'Comedy']},
-            headers={'X-API-Version': '2'})
+        await client.insert_user({'UserId': '3000'})
+        recommendations = await client.get_recommend(
+            '3000', category=['Drama', 'Comedy'], n=3)
+        self.assertEqual(3, len(recommendations))
+        for recommendation in recommendations:
+            item = await client.get_item(recommendation.id)
+            self.assertTrue({'Drama', 'Comedy'} & set(item['Categories']))

--- a/tests/test_gorse.py
+++ b/tests/test_gorse.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from datetime import datetime, UTC
 import unittest
+from unittest.mock import AsyncMock, Mock
 
 from gorse import Gorse, GorseException, AsyncGorse
 
@@ -194,6 +195,18 @@ class TestGorseClient(unittest.TestCase):
         self.assertEqual('1432', recommendations[1].id)
         self.assertEqual('918', recommendations[2].id)
 
+    def test_recommend_multiple_categories(self):
+        client = Gorse(GORSE_ENDPOINT, GORSE_API_KEY)
+        request = Mock(return_value=[])
+        setattr(client, '_Gorse__request', request)
+
+        client.get_recommend('3000', category=['Drama', 'Comedy'], n=3)
+
+        request.assert_called_once_with(
+            'GET', f'{GORSE_ENDPOINT}/api/recommend/3000',
+            params={'n': 3, 'offset': 0, 'category': ['Drama', 'Comedy']},
+            headers={'X-API-Version': '2'})
+
 
 class TestAsyncGorseClient(unittest.IsolatedAsyncioTestCase):
 
@@ -355,3 +368,15 @@ class TestAsyncGorseClient(unittest.IsolatedAsyncioTestCase):
         self.assertEqual('315', recommendations[0].id)
         self.assertEqual('1432', recommendations[1].id)
         self.assertEqual('918', recommendations[2].id)
+
+    async def test_recommend_multiple_categories(self):
+        client = AsyncGorse(GORSE_ENDPOINT, GORSE_API_KEY)
+        request = AsyncMock(return_value=[])
+        setattr(client, '_AsyncGorse__request', request)
+
+        await client.get_recommend('3000', category=['Drama', 'Comedy'], n=3)
+
+        request.assert_awaited_once_with(
+            'GET', f'{GORSE_ENDPOINT}/api/recommend/3000',
+            params={'n': 3, 'offset': 0, 'category': ['Drama', 'Comedy']},
+            headers={'X-API-Version': '2'})


### PR DESCRIPTION
## Summary

- support passing one or more categories to `get_recommend`
- use the current query-parameter API instead of the deprecated category path
- cover synchronous and asynchronous clients

## Tests

- `python -m unittest tests/test_gorse.py -k multiple_categories -v`
- `python -m compileall -q gorse tests`
- `git diff --check`